### PR TITLE
cd pipeline

### DIFF
--- a/.github/workflows/buld-ghcr.yml
+++ b/.github/workflows/buld-ghcr.yml
@@ -1,0 +1,55 @@
+name: Build and Push Docker Image to GHCR
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+env:
+  IMAGE_NAME: voltconnect-frontend
+  REGISTRY_OWNER: tqs-voltconnect
+  REGISTRY: ghcr.io
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Define Docker tags
+        id: vars
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            TAG=${GITHUB_REF#refs/tags/}
+            echo "tag1=$TAG" >> $GITHUB_OUTPUT
+            echo "tag2=latest" >> $GITHUB_OUTPUT
+          else
+            TAG=unstable-$(date +'%y%V%u')
+            echo "tag1=$TAG" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push Docker image (multi-arch)
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.REGISTRY_OWNER }}/${{ env.IMAGE_NAME }}:${{ steps.vars.outputs.tag1 }}
+            ${{ steps.vars.outputs.tag2 && format('{0}/{1}/{2}:{3}', env.REGISTRY, env.REGISTRY_OWNER, env.IMAGE_NAME, steps.vars.outputs.tag2) }}


### PR DESCRIPTION
# CD pipeline

## Description
<!--- Describe your changes in detail. Explain the purpose of this PR and the problem it solves. Include any relevant context or screenshots. -->
This pull request adds a GitHub Actions workflow to automate the process of building and pushing Docker images to the GitHub Container Registry (GHCR). The workflow supports multi-architecture builds and dynamically assigns tags based on the Git reference.

### Automation of Docker image building and pushing:

* [`.github/workflows/buld-ghcr.yml`](diffhunk://#diff-29744db4764ea515a98d6123a3f61387ceea82022646287cb21cb58f91de7c87R1-R55): Introduced a new workflow named "Build and Push Docker Image to GHCR." The workflow triggers on `push` events for tags matching the pattern `v*`, builds multi-architecture Docker images, and pushes them to GHCR with dynamically assigned tags (`latest` for version tags and `unstable-*` for other pushes).