### PR TITLE
frontend seems good now

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,12 +22,10 @@ RUN rm /etc/nginx/conf.d/default.conf
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 COPY --from=builder /app/dist /usr/share/nginx/html
 
-# Copiar o script entrypoint que vai criar o config.js em runtime
 COPY entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh
-
-RUN mkdir -p /run /var/cache/nginx \
-    && chown -R nginx:nginx /run /var/cache/nginx /etc/nginx /usr/share/nginx/html
+RUN chmod +x /entrypoint.sh \
+ && mkdir -p /run /var/cache/nginx \
+ && chown -R nginx:nginx /run /var/cache/nginx /etc/nginx /usr/share/nginx/html
 
 USER nginx
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,7 @@
 
 cat <<EOF > /usr/share/nginx/html/config.js
 window.__RUNTIME_CONFIG__ = {
-  VITE_API_BASE_URL: "${API_BASE_URL}",,
+  VITE_API_BASE_URL: "${API_BASE_URL}",
 };
 EOF
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -9,13 +9,5 @@ server {
         try_files $uri /index.html;
     }
 
-    location /api/ {
-        proxy_pass http://localhost:8080/;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-    }
-
     error_page 404 /index.html;
 }

--- a/src/components/BookingPage.jsx
+++ b/src/components/BookingPage.jsx
@@ -6,7 +6,6 @@ import { baseUrl } from '../consts';
 const BookingPage = () => {
   const { stationId } = useParams();
   const navigate = useNavigate();
-  const baseurl = baseUrl;
 
   const [selectedDate, setSelectedDate] = useState(new Date());
   const [selectedSlot, setSelectedSlot] = useState(null);
@@ -39,7 +38,7 @@ const BookingPage = () => {
   useEffect(() => {
     const fetchStation = async () => {
       try {
-        const response = await fetch(`${baseurl}/stations/${stationId}`);
+        const response = await fetch(`${baseUrl}/stations/${stationId}`);
         if (!response.ok) throw new Error("Failed to fetch station details");
         const data = await response.json();
         const processedStation = {
@@ -64,7 +63,7 @@ const BookingPage = () => {
 
     const fetchVehicles = async () => {
       try {
-        const response = await fetch(`${baseurl}/vehicles`);
+        const response = await fetch(`${baseUrl}/vehicles`);
         if (!response.ok) throw new Error("Failed to fetch vehicles");
         const data = await response.json();
         setVehicles(data);
@@ -145,7 +144,7 @@ const BookingPage = () => {
     };
 
     try {
-      const response = await fetch(`${baseurl}/reservations`, {
+      const response = await fetch(`${baseUrl}/reservations`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(newBooking),

--- a/src/components/MyBookings.jsx
+++ b/src/components/MyBookings.jsx
@@ -5,20 +5,19 @@ const MyBookings = () => {
   const [bookings, setBookings] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
-  const baseurl = baseUrl;
 
   useEffect(() => {
     const fetchBookings = async () => {
       try {
-        const res = await fetch(`${baseurl}/reservations`);
+        const res = await fetch(`${baseUrl}/reservations`);
         const reservations = await res.json();
 
         const detailedBookings = await Promise.all(
           reservations.map(async (reservation) => {
             const [stationRes, chargerRes, vehicleRes] = await Promise.all([
-              fetch(`${baseurl}/stations/${reservation.chargingStationId}`),
-              fetch(`${baseurl}/chargers/${reservation.chargerId}`),
-              fetch(`${baseurl}/vehicles/${reservation.vehicleId}`)
+              fetch(`${baseUrl}/stations/${reservation.chargingStationId}`),
+              fetch(`${baseUrl}/chargers/${reservation.chargerId}`),
+              fetch(`${baseUrl}/vehicles/${reservation.vehicleId}`)
             ]);
 
             const [station, charger, vehicle] = await Promise.all([

--- a/src/components/StationSearch.jsx
+++ b/src/components/StationSearch.jsx
@@ -116,7 +116,7 @@ const StationSearch = () => {
           };
         });
         setStations(transformedStations);
-        const reviewsRes = await fetch(`${baseurl}/reviews`);
+        const reviewsRes = await fetch(`${baseUrl}/reviews`);
         const allReviewsData = await reviewsRes.json();
         setAllReviews(allReviewsData);
         const map = {};

--- a/src/components/StationSearch.jsx
+++ b/src/components/StationSearch.jsx
@@ -8,8 +8,6 @@ import StationListItem from "./StationListItem";
 import PropTypes from "prop-types";
 import { baseUrl } from "../consts";
 
-const baseurl = baseUrl;
-
 delete L.Icon.Default.prototype._getIconUrl;
 L.Icon.Default.mergeOptions({
   iconRetinaUrl:
@@ -89,8 +87,8 @@ const StationSearch = () => {
       try {
         setLoading(true);
         setError(null);
-        setReviewsLoading(true);
-        const response = await axios.get(`${baseurl}/stations`);
+
+        const response = await axios.get(`${baseUrl}/stations`);
         const rawData = response.data;
         if (!Array.isArray(rawData)) {
           throw new Error("Response format invalid: expected an array");


### PR DESCRIPTION
# More frontend changes in deployment

## Description
<!--- Describe your changes in detail. Explain the purpose of this PR and the problem it solves. Include any relevant context or screenshots. -->
This pull request introduces several changes to improve the codebase by cleaning up redundant variables, simplifying configuration files, and removing unused API routes. The most significant updates involve standardizing the usage of `baseUrl` across components, modifying the `Dockerfile` for better runtime efficiency, and simplifying the `nginx.conf` file by removing unnecessary configurations.

### Configuration Improvements:
* **Dockerfile**: Streamlined the `RUN` command to combine multiple operations into a single line for better efficiency. Removed redundant comments and adjusted permissions setup.
* **`nginx.conf`**: Removed the `/api/` location block, simplifying the configuration and eliminating unused proxy settings.

### Code Cleanup:
* **`entrypoint.sh`**: Fixed a syntax error by removing an extra comma in the `VITE_API_BASE_URL` assignment.

### Standardization of `baseUrl` Usage:
* **`src/components/BookingPage.jsx`**: Replaced all occurrences of `baseurl` with `baseUrl` to ensure consistency and eliminate redundant variable declarations. [[1]](diffhunk://#diff-0e6a189721eabf82eed5a8c88b7a0bec45bd9a383362b393080f3653651e6827L9) [[2]](diffhunk://#diff-0e6a189721eabf82eed5a8c88b7a0bec45bd9a383362b393080f3653651e6827L42-R41) [[3]](diffhunk://#diff-0e6a189721eabf82eed5a8c88b7a0bec45bd9a383362b393080f3653651e6827L67-R66) [[4]](diffhunk://#diff-0e6a189721eabf82eed5a8c88b7a0bec45bd9a383362b393080f3653651e6827L148-R147)
* **`src/components/MyBookings.jsx`**: Updated all fetch calls to use `baseUrl` directly, removing the unnecessary `baseurl` variable.
* **`src/components/StationSearch.jsx`**: Removed the redundant `baseurl` variable and updated the Axios call to use `baseUrl`. [[1]](diffhunk://#diff-b2c52226a9bb7da052aaa813ed116203e6f125012048638b743f59168a10a61dL11-L12) [[2]](diffhunk://#diff-b2c52226a9bb7da052aaa813ed116203e6f125012048638b743f59168a10a61dL93-R91)

